### PR TITLE
Fixing Download-Link after Repo has been moved

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-DOWNLOAD_URL=$(curl -s https://api.github.com/repos/stratum0/stratum0beamer/releases | grep browser_download_url | head -n 1 |sed -E 's/[[:space:]]*"[a-z_]*": "([a-zA-Z0-9_.:/\-]*)"/\1/')
+DOWNLOAD_URL=$(curl -s https://api.github.com/repos/stratum0/stratum0-latex/releases | grep browser_download_url | head -n 1 |sed -E 's/[[:space:]]*"[a-z_]*": "([a-zA-Z0-9_.:/\-]*)"/\1/')
 UNZIP_DIR=$(mktemp -d /tmp/stratum0beamer.XXXXXXXX)
 UNZIP_FILE=${UNZIP_DIR}/stratum0beamer.zip
 curl -L "${DOWNLOAD_URL}" > "${UNZIP_FILE}"


### PR DESCRIPTION
It seems the Github-Repo has been moved / renamed from
https://github.com/stratum0/stratum0beamer
to
https://github.com/stratum0/stratum0-latex

This broke the Setup-Script. This commit fixes the Download-Link.

Signed-off-by: Chrissi^ <chris@tinyhost.de>